### PR TITLE
vim: add extra session file Sessionx.vim

### DIFF
--- a/Global/Vim.gitignore
+++ b/Global/Vim.gitignore
@@ -7,6 +7,7 @@
 
 # Session
 Session.vim
+Sessionx.vim
 
 # Temporary
 .netrwhist


### PR DESCRIPTION
from vim's documentation on `:mksession` (:help :mksession):

 ...

 10. If a file exists with the same name as the Session file, but ending
     in "x.vim" (for eXtra), executes that as well.  You can use *x.vim
     files to specify additional settings and actions associated with a
     given Session, such as creating menu items in the GUI version.

we already have Session.vim ignored.  the Sessionx.vim file, like
Session.vim, is a user file.  a user would generally want that file kept
private or for themselves, and the public or a team fetching from or
sharing the repository generally have no interest in a file relevant
only to a particular user.  so it's a good idea to get git to help us
avoid mistakenly sharing the file.